### PR TITLE
bugfix

### DIFF
--- a/CloakOfDarkness/CloakOfDarkness.grif
+++ b/CloakOfDarkness/CloakOfDarkness.grif
@@ -1,6 +1,6 @@
 // CloakOfDarkness.grif - GRIF format
 @__version
-	Version 2025.05.22
+	Version 2025.07.31
 @addscore(x)
 	@if @ne($x,0) @then
 		@addto(value.score,$x)
@@ -38,6 +38,10 @@
 	@endif
 @goto(x)
 	@debug("goto $x")
+	@if @null(@get(room.$x.longdesc)) @and @null(@get(room.$x.shortdesc)) @then
+		@writeline("Invalid room: $x")
+		@return
+	@endif
 	@set(value.room,$x)
 	@look
 @here(x)

--- a/GRIF/GRIF.csproj
+++ b/GRIF/GRIF.csproj
@@ -14,7 +14,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/BakkerGames/GRIF</RepositoryUrl>
     <Title>GRIF - Game Runner for Interactive Fiction</Title>
-    <Version>2025.7.21</Version>
+    <Version>2025.7.31</Version>
     <PackageTags>grif;game;engine;runner;interactive;fiction;text;adventure;if</PackageTags>
     <AssemblyName>grif</AssemblyName>
   </PropertyGroup>

--- a/GRIFTools/DAGS/Dags.Run.cs
+++ b/GRIFTools/DAGS/Dags.Run.cs
@@ -190,6 +190,7 @@ public partial class Dags
                 if (ConvertToBool(Get(DEBUG_MODE)))
                 {
                     // display values in debug mode
+                    result.Append("### "); // debug prefix
                     result.Append(p[0]);
                     result.Append(NL_VALUE);
                 }
@@ -865,7 +866,8 @@ public partial class Dags
         // @if <conditions> @then ... [@elseif <conditions> @then ...] [<repeat>] [@else ...] @endif
         if (CheckConditions(tokens, ref index))
         {
-            while (!tokens[index].Equals(ELSE, OIC) &&
+            while (index < tokens.Length &&
+                   !tokens[index].Equals(ELSE, OIC) &&
                    !tokens[index].Equals(ELSEIF, OIC) &&
                    !tokens[index].Equals(ENDIF, OIC))
             {
@@ -983,7 +985,7 @@ public partial class Dags
     private static void SkipPastEndif(string[] tokens, ref int index)
     {
         int level = 0;
-        while (!tokens[index].Equals(ENDIF, OIC) || level > 0)
+        while (index < tokens.Length && !tokens[index].Equals(ENDIF, OIC) || level > 0)
         {
             if (tokens[index].Equals(IF, OIC))
             {

--- a/GRIFTools/GRIFTools.csproj
+++ b/GRIFTools/GRIFTools.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2025.7.21</Version>
+    <Version>2025.7.31</Version>
     <Copyright>Copyright (C) 2023-2025 by Scott Bakker</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>

--- a/GRIFTools/Parse/Parse.cs
+++ b/GRIFTools/Parse/Parse.cs
@@ -64,11 +64,11 @@ public static class Parse
             GetNoun(result, words, ref index);
             if (result.Error == "" && result.Noun != "")
             {
-                result.Error = string.Format(DO_WHAT_WITH_NOUN, words[0]);
+                result.Error = string.Format(DO_WHAT_WITH_NOUN, input);
             }
             else
             {
-                result.Error = string.Format(DONT_UNDERSTAND_WORD, words[0]);
+                result.Error = string.Format(DONT_UNDERSTAND_INPUT, input);
             }
             return result;
         }
@@ -207,6 +207,10 @@ public static class Parse
 
         // adjectives
         var adjectiveNounList = CheckAdjectives(words, ref index);
+        if (index >= words.Length)
+        {
+            return;
+        }
 
         // get the noun
         string origWord = words[index];
@@ -373,6 +377,15 @@ public static class Parse
 
         do
         {
+            if (newIndex >= words.Length)
+            {
+                // no more words to check
+                if (firstTime)
+                {
+                    return null; // never found an adjective
+                }
+                break; // found at least one adjective, but no more words
+            }
             foundOne = false;
             string origWord = words[newIndex];
             var shortWord = FixLength(origWord);


### PR DESCRIPTION
Corrected some index overflow errors. Changed "Do what with" and "Don't understand" errors to show the whole input instead of a single word, in case of adjectives. Added "###" prefix to debug statements. Fixed "Cloak of Darkness" to show an error when going to a non-existing location during debug, such as "@&ZeroWidthSpace;goto(outside)".